### PR TITLE
MapChipInfoを整理

### DIFF
--- a/Point-of-No-Return/Character.cpp
+++ b/Point-of-No-Return/Character.cpp
@@ -89,13 +89,13 @@ void Hero::CorrectCoordinate(Direction direction, const Vec2& blockPosition)
 		position.y.value = blockPosition.y.value - size.height.value;
 		break;			  
 	case Direction::Down:
-		position.y.value = blockPosition.y.value + MapChipInfo::chip_size;
+		position.y.value = blockPosition.y.value + Mapchip::chip_size;
 		break;			  
 	case Direction::Left:
 		position.x.value = blockPosition.x.value - size.width.value;
 		break;			  
 	case Direction::Right:
-		position.x.value = blockPosition.x.value + MapChipInfo::chip_size;
+		position.x.value = blockPosition.x.value + Mapchip::chip_size;
 		break;
 	default:
 

--- a/Point-of-No-Return/Character.cpp
+++ b/Point-of-No-Return/Character.cpp
@@ -51,11 +51,11 @@ void Hero::Update()
 //	{
 //		//
 //		if ((vec2[i].x.value < vec.x.value + size.width.value) &&
-//			(vec.x.value < vec2[i].x.value + chip_size) &&
+//			(vec.x.value < vec2[i].x.value + CHIP_SIZE) &&
 //			(vec2[i].y.value < vec.y.value + size.height.value) &&
-//			(vec.y.value < vec2[i].y.value + chip_size))
+//			(vec.y.value < vec2[i].y.value + CHIP_SIZE))
 //		{
-//			if ((previous.y.value + size.height.value <= vec2[i].y.value) || (previous.y.value >= vec2[i].y.value + chip_size))
+//			if ((previous.y.value + size.height.value <= vec2[i].y.value) || (previous.y.value >= vec2[i].y.value + CHIP_SIZE))
 //			{
 //				if (vector_y < 0)
 //				{
@@ -63,7 +63,7 @@ void Hero::Update()
 //				}
 //				else if (vector_y > 0)
 //				{
-//					vec.y.value = vec2[i].y.value + chip_size;
+//					vec.y.value = vec2[i].y.value + CHIP_SIZE;
 //				}
 //			}
 //			else
@@ -74,7 +74,7 @@ void Hero::Update()
 //				}
 //				else if (vector_x > 0)
 //				{
-//					vec.x.value = vec2[i].x.value + chip_size;
+//					vec.x.value = vec2[i].x.value + CHIP_SIZE;
 //				}
 //			}
 //		}
@@ -89,13 +89,13 @@ void Hero::CorrectCoordinate(Direction direction, const Vec2& blockPosition)
 		position.y.value = blockPosition.y.value - size.height.value;
 		break;			  
 	case Direction::Down:
-		position.y.value = blockPosition.y.value + Mapchip::chip_size;
+		position.y.value = blockPosition.y.value + Mapchip::CHIP_SIZE;
 		break;			  
 	case Direction::Left:
 		position.x.value = blockPosition.x.value - size.width.value;
 		break;			  
 	case Direction::Right:
-		position.x.value = blockPosition.x.value + Mapchip::chip_size;
+		position.x.value = blockPosition.x.value + Mapchip::CHIP_SIZE;
 		break;
 	default:
 

--- a/Point-of-No-Return/Collision.cpp
+++ b/Point-of-No-Return/Collision.cpp
@@ -22,7 +22,7 @@ bool HitCheckEdge(Direction* direction, Vec2 characterPrevious, Size characterSi
 	float characterTop = characterPrevious.y.value;
 	float characterBottom = characterTop + characterSize.height.value;
 	float blockTop = blockPosition.y.value;
-	float blockBottom = blockTop + Mapchip::chip_size;
+	float blockBottom = blockTop + Mapchip::CHIP_SIZE;
 
 	// キャラクターが前のフレームでブロックの上下にいるとき
 	if ((characterBottom <= blockTop) || (characterTop >= blockBottom))
@@ -65,9 +65,9 @@ bool isHItBlock(Vec2 characterPrevious, Size characterSize, Vec2 characterPositi
 	float characterBottom = characterTop + characterSize.height.value;
 
 	float blockLeft = blockPosition.x.value;
-	float blockRight = blockLeft + Mapchip::chip_size;
+	float blockRight = blockLeft + Mapchip::CHIP_SIZE;
 	float blockTop = blockPosition.y.value;
-	float blockBottom = blockTop + Mapchip::chip_size;
+	float blockBottom = blockTop + Mapchip::CHIP_SIZE;
 
 	return (blockLeft < characterRight) &&
 		(characterLeft < blockRight) &&
@@ -93,8 +93,8 @@ std::vector<Vec2> SearchBlock(const Vec2& character_pos, const Size& size, int**
 
 	Matrix search_start =
 	{
-		Col(center_x / Mapchip::chip_size - 2),
-		Row(center_y / Mapchip::chip_size - 2)
+		Col(center_x / Mapchip::CHIP_SIZE - 2),
+		Row(center_y / Mapchip::CHIP_SIZE - 2)
 	};
 
 	for (int i = 0; i < 5; i++)
@@ -106,8 +106,8 @@ std::vector<Vec2> SearchBlock(const Vec2& character_pos, const Size& size, int**
 
 			if (map[current_row][current_col] != 0)
 			{
-				vec2.x.value = current_col * Mapchip::chip_size;
-				vec2.y.value = current_row * Mapchip::chip_size;
+				vec2.x.value = current_col * Mapchip::CHIP_SIZE;
+				vec2.y.value = current_row * Mapchip::CHIP_SIZE;
 				mapdata.push_back(vec2);
 			}
 		}

--- a/Point-of-No-Return/Collision.cpp
+++ b/Point-of-No-Return/Collision.cpp
@@ -4,9 +4,6 @@
 
 #include "Object.h"
 
-
-
-
 namespace
 {
 
@@ -25,7 +22,7 @@ bool HitCheckEdge(Direction* direction, Vec2 characterPrevious, Size characterSi
 	float characterTop = characterPrevious.y.value;
 	float characterBottom = characterTop + characterSize.height.value;
 	float blockTop = blockPosition.y.value;
-	float blockBottom = blockTop + MapChipInfo::chip_size;
+	float blockBottom = blockTop + Mapchip::chip_size;
 
 	// キャラクターが前のフレームでブロックの上下にいるとき
 	if ((characterBottom <= blockTop) || (characterTop >= blockBottom))
@@ -68,9 +65,9 @@ bool isHItBlock(Vec2 characterPrevious, Size characterSize, Vec2 characterPositi
 	float characterBottom = characterTop + characterSize.height.value;
 
 	float blockLeft = blockPosition.x.value;
-	float blockRight = blockLeft + MapChipInfo::chip_size;
+	float blockRight = blockLeft + Mapchip::chip_size;
 	float blockTop = blockPosition.y.value;
-	float blockBottom = blockTop + MapChipInfo::chip_size;
+	float blockBottom = blockTop + Mapchip::chip_size;
 
 	return (blockLeft < characterRight) &&
 		(characterLeft < blockRight) &&
@@ -96,8 +93,8 @@ std::vector<Vec2> SearchBlock(const Vec2& character_pos, const Size& size, int**
 
 	Matrix search_start =
 	{
-		Col(center_x / MapChipInfo::chip_size - 2),
-		Row(center_y / MapChipInfo::chip_size - 2)
+		Col(center_x / Mapchip::chip_size - 2),
+		Row(center_y / Mapchip::chip_size - 2)
 	};
 
 	for (int i = 0; i < 5; i++)
@@ -109,8 +106,8 @@ std::vector<Vec2> SearchBlock(const Vec2& character_pos, const Size& size, int**
 
 			if (map[current_row][current_col] != 0)
 			{
-				vec2.x.value = current_col * MapChipInfo::chip_size;
-				vec2.y.value = current_row * MapChipInfo::chip_size;
+				vec2.x.value = current_col * Mapchip::chip_size;
+				vec2.y.value = current_row * Mapchip::chip_size;
 				mapdata.push_back(vec2);
 			}
 		}

--- a/Point-of-No-Return/Game.cpp
+++ b/Point-of-No-Return/Game.cpp
@@ -30,7 +30,7 @@ void Game::Draw()
 {
 	float a = 1.0f / 16.0f;
 	dx.DrawEx(0, 0, 0, 1920, 1080, 0, 1, 0, "game_back", 0, 0, a, 1);
-	mapchip.DrawMapchip(world_size_width, world_size_height, texture_width, texture_height, chip_width_num, chip_height_num, chip_size, chip_size, 0, 0, "blocks", mapchip.map_);
+	mapchip.DrawMapchip(Mapchip::world_size_width, Mapchip::world_size_height, Mapchip::texture_width, Mapchip::texture_height, Mapchip::chip_width_num, Mapchip::chip_height_num, Mapchip::chip_size, Mapchip::chip_size, 0, 0, "blocks", mapchip.map_);
 	hero.Draw();
 
 	// ----------- 当たり判定の為の仮置き --------------

--- a/Point-of-No-Return/Game.cpp
+++ b/Point-of-No-Return/Game.cpp
@@ -30,7 +30,7 @@ void Game::Draw()
 {
 	float a = 1.0f / 16.0f;
 	dx.DrawEx(0, 0, 0, 1920, 1080, 0, 1, 0, "game_back", 0, 0, a, 1);
-	mapchip.DrawMapchip(Mapchip::world_size_width, Mapchip::world_size_height, Mapchip::texture_width, Mapchip::texture_height, Mapchip::chip_width_num, Mapchip::chip_height_num, Mapchip::chip_size, Mapchip::chip_size, 0, 0, "blocks", mapchip.map_);
+	mapchip.DrawMapchip(Mapchip::WORLD_SIZE_WIDTH, Mapchip::WORLD_SIZE_HEIGHT, Mapchip::TEXTURE_WIDTH, Mapchip::TEXTURE_HEIGHT, Mapchip::CHIP_WIDTH_NUM, Mapchip::CHIP_HEIGHT_NUM, Mapchip::CHIP_SIZE, Mapchip::CHIP_SIZE, 0, 0, "blocks", mapchip.map_);
 	hero.Draw();
 
 	// ----------- 当たり判定の為の仮置き --------------

--- a/Point-of-No-Return/Game.cpp
+++ b/Point-of-No-Return/Game.cpp
@@ -30,7 +30,7 @@ void Game::Draw()
 {
 	float a = 1.0f / 16.0f;
 	dx.DrawEx(0, 0, 0, 1920, 1080, 0, 1, 0, "game_back", 0, 0, a, 1);
-	mapchip.DrawMapchip(Mapchip::WORLD_SIZE_WIDTH, Mapchip::WORLD_SIZE_HEIGHT, Mapchip::TEXTURE_WIDTH, Mapchip::TEXTURE_HEIGHT, Mapchip::CHIP_WIDTH_NUM, Mapchip::CHIP_HEIGHT_NUM, Mapchip::CHIP_SIZE, Mapchip::CHIP_SIZE, 0, 0, "blocks", mapchip.map_);
+	mapchip.DrawMapchip(0, 0, "blocks", mapchip.map_);
 	hero.Draw();
 
 	// ----------- 当たり判定の為の仮置き --------------

--- a/Point-of-No-Return/Game.h
+++ b/Point-of-No-Return/Game.h
@@ -7,8 +7,6 @@
 #include "Character.h"
 #include "Collision.h"
 
-using namespace MapChipInfo;
-
 /**
  * @brief ゲームシーン
  */

--- a/Point-of-No-Return/Mapchip.cpp
+++ b/Point-of-No-Return/Mapchip.cpp
@@ -4,7 +4,6 @@
 #include "Main.h"
 #include "string"
 
-
 void Mapchip::DrawMapchip(int map_size_width, int map_size_height, float texture_width, float texture_height, float mapchip_width, float mapchip_height, float draw_width, float draw_height, float draw_pos_x, float draw_pos_y, std::string texturename, int** map)
 {
 	int width_num = texture_width / mapchip_width;
@@ -40,9 +39,9 @@ void Mapchip::TexturePrint(int drawpos_x, int drawpos_y, int mapcip_width, int m
 void Mapchip::InitMap()
 {
 	//α用のマップ
-	for (int i = 0; i < MapChipInfo::world_size_height; i++)
+	for (int i = 0; i < world_size_height; i++)
 	{
-		for (int j = 0; j < MapChipInfo::world_size_width; j++)
+		for (int j = 0; j < world_size_width; j++)
 		{
 			if (i == 14 || i == 15)
 			{
@@ -51,7 +50,7 @@ void Mapchip::InitMap()
 		}
 	}
 	
-	for (int i = 0; i < MapChipInfo::world_size_height; i++)
+	for (int i = 0; i < world_size_height; i++)
 	{
 		map_[i] = map[i];
 	}
@@ -61,8 +60,8 @@ void Mapchip::InitMap()
 
 int Mapchip::CalcMapNumber(int x, int y)
 {
-	int col = (x / MapChipInfo::chip_size) * MapChipInfo::chip_size;
-	int row = (y / MapChipInfo::chip_size) * MapChipInfo::chip_size;
+	int col = (x / chip_size) * chip_size;
+	int row = (y / chip_size) * chip_size;
 	
 	return map[row][col];
 }

--- a/Point-of-No-Return/Mapchip.cpp
+++ b/Point-of-No-Return/Mapchip.cpp
@@ -21,22 +21,25 @@ void Mapchip::DrawMapchip(float draw_start_pos_x, float draw_start_pos_y, std::s
 
 			float draw_pos_x = draw_start_pos_x + CHIP_SIZE * j;
 			float draw_pos_y = draw_start_pos_y + CHIP_SIZE * i;
-			float chip_pos_x = (float)(chip_id % width_num) * CHIP_WIDTH_NUM / TEXTURE_WIDTH;
-			float chip_pos_y = (float)(chip_id / height_num) * CHIP_HEIGHT_NUM / TEXTURE_HEIGHT;
-			TexturePrint(draw_pos_x, draw_pos_y, chip_pos_x, chip_pos_y, texturename);
+			float tu = (float)(chip_id % width_num) * CHIP_WIDTH_NUM / TEXTURE_WIDTH;
+			float tv = (float)(chip_id / height_num) * CHIP_HEIGHT_NUM / TEXTURE_HEIGHT;
+			TexturePrint(draw_pos_x, draw_pos_y, tu, tv, texturename);
 		}
 	}
 }
 
 //マップチップ描画
-void Mapchip::TexturePrint(float drawpos_x, float drawpos_y, float chip_pos_x, float chip_pos_y, std::string texturename)
+void Mapchip::TexturePrint(float drawpos_x, float drawpos_y, float tu, float tv, std::string texturename)
 {
 	DirectX& dx = DirectX::GetInstance();
 
-	float width_num = static_cast<float>(CHIP_WIDTH_NUM) / TEXTURE_WIDTH;
-	float height_num = static_cast<float>(CHIP_HEIGHT_NUM) / TEXTURE_HEIGHT;
+	float width = static_cast<float>(CHIP_SIZE);
+	float height = static_cast<float>(CHIP_SIZE);
 
-	dx.DrawEx(drawpos_x, drawpos_y, 0, CHIP_SIZE, CHIP_SIZE, 0, 1.f, false, texturename, chip_pos_x, chip_pos_y, width_num, height_num);
+	float tu_width = static_cast<float>(CHIP_WIDTH_NUM) / TEXTURE_WIDTH;
+	float tv_height = static_cast<float>(CHIP_HEIGHT_NUM) / TEXTURE_HEIGHT;
+
+	dx.DrawEx(drawpos_x, drawpos_y, 0.0f, width, height, 0.0f, 1.0f, false, texturename, tu, tv, tu_width, tv_height);
 }
 
 

--- a/Point-of-No-Return/Mapchip.cpp
+++ b/Point-of-No-Return/Mapchip.cpp
@@ -4,14 +4,14 @@
 #include "Main.h"
 #include "string"
 
-void Mapchip::DrawMapchip(int map_size_width, int map_size_height, float texture_width, float texture_height, float mapchip_width, float mapchip_height, float draw_width, float draw_height, float draw_pos_x, float draw_pos_y, std::string texturename, int** map)
+void Mapchip::DrawMapchip(float draw_start_pos_x, float draw_start_pos_y, std::string texturename, int** map)
 {
-	int width_num = texture_width / mapchip_width;
-	int height_num = texture_height / mapchip_height;
+	int width_num = TEXTURE_WIDTH / CHIP_WIDTH_NUM;
+	int height_num = TEXTURE_HEIGHT / CHIP_HEIGHT_NUM;
 
-	for (int i = 0; i < map_size_height; i++)
+	for (int i = 0; i < WORLD_SIZE_HEIGHT; i++)
 	{
-		for (int j = 0; j < map_size_width; j++)
+		for (int j = 0; j < WORLD_SIZE_WIDTH; j++)
 		{
 			int chip_id = map[i][j];
 			if (chip_id == 0)
@@ -19,20 +19,24 @@ void Mapchip::DrawMapchip(int map_size_width, int map_size_height, float texture
 				continue;
 			}
 
-			float chip_pos_x = (float)(chip_id % width_num) * mapchip_width;
-			float chip_pos_y = (float)(chip_id / height_num) * mapchip_height;
-
-			TexturePrint(draw_pos_x + draw_width * j, draw_pos_y + draw_height * i, draw_width, draw_height, chip_pos_x / texture_width, chip_pos_y / texture_height, mapchip_width / texture_width, mapchip_height / texture_height, texturename);
+			float draw_pos_x = draw_start_pos_x + CHIP_SIZE * j;
+			float draw_pos_y = draw_start_pos_y + CHIP_SIZE * i;
+			float chip_pos_x = (float)(chip_id % width_num) * CHIP_WIDTH_NUM / TEXTURE_WIDTH;
+			float chip_pos_y = (float)(chip_id / height_num) * CHIP_HEIGHT_NUM / TEXTURE_HEIGHT;
+			TexturePrint(draw_pos_x, draw_pos_y, chip_pos_x, chip_pos_y, texturename);
 		}
 	}
 }
 
 //マップチップ描画
-void Mapchip::TexturePrint(int drawpos_x, int drawpos_y, int mapcip_width, int mapchip_height, float chip_pos_x, float chip_pos_y, float width_num, float height_num, std::string texturename)
+void Mapchip::TexturePrint(float drawpos_x, float drawpos_y, float chip_pos_x, float chip_pos_y, std::string texturename)
 {
 	DirectX& dx = DirectX::GetInstance();
 
-	dx.DrawEx(drawpos_x, drawpos_y, 0, mapcip_width, mapchip_height, 0, 1.f, 0, texturename, chip_pos_x, chip_pos_y, width_num, height_num);
+	float width_num = static_cast<float>(CHIP_WIDTH_NUM) / TEXTURE_WIDTH;
+	float height_num = static_cast<float>(CHIP_HEIGHT_NUM) / TEXTURE_HEIGHT;
+
+	dx.DrawEx(drawpos_x, drawpos_y, 0, CHIP_SIZE, CHIP_SIZE, 0, 1.f, false, texturename, chip_pos_x, chip_pos_y, width_num, height_num);
 }
 
 

--- a/Point-of-No-Return/Mapchip.cpp
+++ b/Point-of-No-Return/Mapchip.cpp
@@ -39,9 +39,9 @@ void Mapchip::TexturePrint(int drawpos_x, int drawpos_y, int mapcip_width, int m
 void Mapchip::InitMap()
 {
 	//α用のマップ
-	for (int i = 0; i < world_size_height; i++)
+	for (int i = 0; i < WORLD_SIZE_HEIGHT; i++)
 	{
-		for (int j = 0; j < world_size_width; j++)
+		for (int j = 0; j < WORLD_SIZE_WIDTH; j++)
 		{
 			if (i == 14 || i == 15)
 			{
@@ -50,7 +50,7 @@ void Mapchip::InitMap()
 		}
 	}
 	
-	for (int i = 0; i < world_size_height; i++)
+	for (int i = 0; i < WORLD_SIZE_HEIGHT; i++)
 	{
 		map_[i] = map[i];
 	}
@@ -60,8 +60,8 @@ void Mapchip::InitMap()
 
 int Mapchip::CalcMapNumber(int x, int y)
 {
-	int col = (x / chip_size) * chip_size;
-	int row = (y / chip_size) * chip_size;
+	int col = (x / CHIP_SIZE) * CHIP_SIZE;
+	int row = (y / CHIP_SIZE) * CHIP_SIZE;
 	
 	return map[row][col];
 }

--- a/Point-of-No-Return/Mapchip.h
+++ b/Point-of-No-Return/Mapchip.h
@@ -8,16 +8,16 @@
 class Mapchip {
 public:
 	// ワールドのサイズ
-	static const int world_size_width = 480;
-	static const int world_size_height = 17;
+	static const int WORLD_SIZE_WIDTH = 480;
+	static const int WORLD_SIZE_HEIGHT = 17;
 	// 一つのチップのサイズ
-	static const int chip_size = 64;
+	static const int CHIP_SIZE = 64;
 	// テクスチャのサイズ
-	static const int texture_width = 256;
-	static const int texture_height = 256;
+	static const int TEXTURE_WIDTH = 256;
+	static const int TEXTURE_HEIGHT = 256;
 	// テクスチャ一つに対するチップの番号
-	static const int chip_width_num = texture_width / 4;
-	static const int chip_height_num = texture_height / 4;
+	static const int CHIP_WIDTH_NUM = TEXTURE_WIDTH / 4;
+	static const int CHIP_HEIGHT_NUM = TEXTURE_HEIGHT / 4;
 
 	/**
 	 * @brief  マップチップを描画する関数
@@ -53,11 +53,11 @@ public:
 	int CalcMapNumber(int x, int y);
 
 	//! マップの情報を保存するポインタ配列
-	int* map_[world_size_height];
+	int* map_[WORLD_SIZE_HEIGHT];
 
 private:
 	//! マップの二重配列
-	int map[world_size_height][world_size_width] = {};
+	int map[WORLD_SIZE_HEIGHT][WORLD_SIZE_WIDTH] = {};
 
 };
 

--- a/Point-of-No-Return/Mapchip.h
+++ b/Point-of-No-Return/Mapchip.h
@@ -26,7 +26,7 @@ public:
 	 * @param  
 	 * @details 
 	 */
-	void DrawMapchip(int map_size_width, int map_size_height, float texture_width, float texture_height, float mapchip_width, float mapchip_height, float draw_width, float draw_height, float draw_pos_x, float draw_pos_y, std::string texturename, int** map);
+	void DrawMapchip(float draw_start_pos_x, float draw_start_pos_y, std::string texturename, int** map);
 
 	/**
 	 * @brief  
@@ -35,7 +35,7 @@ public:
 	 * @param  
 	 * @details 
 	 */
-	void TexturePrint(int drawpos_x, int drawpos_y, int mapcip_width, int mapchip_height, float chip_pos_x, float chip_pos_y, float width_num, float height_num, std::string texturename);
+	void TexturePrint(float drawpos_x, float drawpos_y, float chip_pos_x, float chip_pos_y, std::string texturename);
 
 	/**
 	 * @brief	マップの初期化

--- a/Point-of-No-Return/Mapchip.h
+++ b/Point-of-No-Return/Mapchip.h
@@ -4,24 +4,21 @@
 #include<iostream>
 #include<stdio.h>
 
-namespace MapChipInfo
-{
-	// ワールドのサイズ
-	const int world_size_width = 480;
-	const int world_size_height = 17;
-	// 一つのチップのサイズ
-	const int chip_size = 64;
-	// テクスチャのサイズ
-	const int texture_width = 256;
-	const int texture_height = 256;
-	// テクスチャ一つに対するチップの番号
-	const int chip_width_num = texture_width / 4;
-	const int chip_height_num = texture_height / 4;
-}
-
 // TODO: 引数などを修正したいので、doxygenコメントはリファクタリング時に記入する
 class Mapchip {
 public:
+	// ワールドのサイズ
+	static const int world_size_width = 480;
+	static const int world_size_height = 17;
+	// 一つのチップのサイズ
+	static const int chip_size = 64;
+	// テクスチャのサイズ
+	static const int texture_width = 256;
+	static const int texture_height = 256;
+	// テクスチャ一つに対するチップの番号
+	static const int chip_width_num = texture_width / 4;
+	static const int chip_height_num = texture_height / 4;
+
 	/**
 	 * @brief  マップチップを描画する関数
 	 * @param  
@@ -56,11 +53,11 @@ public:
 	int CalcMapNumber(int x, int y);
 
 	//! マップの情報を保存するポインタ配列
-	int* map_[MapChipInfo::world_size_height];
+	int* map_[world_size_height];
 
 private:
 	//! マップの二重配列
-	int map[MapChipInfo::world_size_height][MapChipInfo::world_size_width] = {};
+	int map[world_size_height][world_size_width] = {};
 
 };
 

--- a/Point-of-No-Return/Mapchip.h
+++ b/Point-of-No-Return/Mapchip.h
@@ -35,7 +35,7 @@ public:
 	 * @param  
 	 * @details 
 	 */
-	void TexturePrint(float drawpos_x, float drawpos_y, float chip_pos_x, float chip_pos_y, std::string texturename);
+	void TexturePrint(float drawpos_x, float drawpos_y, float tu, float tv, std::string texturename);
 
 	/**
 	 * @brief	マップの初期化


### PR DESCRIPTION
## 概要
PR #39 の作業で、namespace `MapChipInfo` の扱いがややこしくなってきたので整理する。
<!-- 関連するissue番号 -->
refs #5

## 変更内容
<!-- 変更した内容 -->
* [x] namespace MapChipInfo内の定数群をMapchipクラスに移動
* [x] 定数を大文字に変更
* [x] 不要そうな引数を削除
* [x] 仮引数とローカル変数の名前を、DirectX#DrawEX()の仮引数名に合わせて変更

## 補足
<!-- 何かコメントを残すことがあれば -->
下記2点の指摘に対する解決策を考えてみました。
* https://github.com/human-osaka-game-2019/Point-of-No-Return/pull/39#pullrequestreview-320676658
* https://github.com/human-osaka-game-2019/Point-of-No-Return/pull/39#pullrequestreview-321896046

問題無ければ `feature/#5` のbranchに取り込んで貰えればと思います。
見当違いのことをしているようでしたら却下して下さい。

### さらに補足
`Game#Draw()` の中で `Mapchip#DrawMapchip()` を呼ぶ際に `MapChipInfo` の定数を使いまくっているのをなんとか整理できないか？と思ったところから始まっています。

思考の流れとしては
1. `MapChipInfo` namespaceの中は定数しか無い & `Mapchip` というクラスが存在する → 定数をクラスに入れてしまえば良いのでは？
1. それらの定数を `Mapchip` クラスの配列メンバの要素数指定に使用している → static constにしてしまえば良いのでは？
1. 定数の命名規則がわからん → とりあえず全部大文字にしてsnake patternにしちゃおう
1. 「関数呼び出し部分が長くて読む気しない！」と [指摘した箇所](https://github.com/human-osaka-game-2019/Point-of-No-Return/pull/39#pullrequestreview-320676658) 、よく見るとその関数は他で使っていなさそう
1. その上、その関数は `Mapchip` クラスのmethodなので、だったら `Mapchip` クラスに任せてしまおう(要らん引数減らそう)！

みたいな感じです。

`Mapchip#TexturePrint()` の中でtu/tvの幅と高さを計算することになりましたが、定数同士の計算の結果定数になっているのは変な気がします。
しかも `64 / 256` で `0.25` になっていますが、それで良いのでしょうか…？