### PR TITLE
当たり判定のbug修正#81

### DIFF
--- a/Point-of-No-Return/Collision.cpp
+++ b/Point-of-No-Return/Collision.cpp
@@ -6,6 +6,9 @@
 
 namespace
 {
+	//! 当たり判定する列の順番を保存する配列
+	const int COLLISION_JUDGEMENT_ORDER[5] = { 2,1,3,0,4 };
+
 
 // TODO: collision引数Hero修正しないといけない
 /**
@@ -111,7 +114,7 @@ std::vector<Position> SearchBlock(Character& character, int** map)
 		for (int j = 0; j < 5; j++)
 		{
 			int current_col = search_start.col.value + j;
-			int current_row = search_start.row.value + i;
+			int current_row = search_start.row.value + COLLISION_JUDGEMENT_ORDER[i];
 
 			if (map[current_row][current_col] != 0)
 			{
@@ -133,16 +136,15 @@ std::vector<Position> SearchBlock(Character& character, int** map)
 
 void CheckBlock(Character* character, std::vector<Position> blockPositions)
 {
-	auto characterPosition = character->GetPos();
 	auto characterPrevious = character->GetPreviousPosition();
 	auto characterSize = character->GetSize();
-	auto offsetPrevious = character->GetPreviousOffset();
-	auto offset = character->GetOffset();
-
 	auto vector = character->GetVector();
 
 	for (auto blockPosition : blockPositions)
 	{
+		// キャラクターの位置だけ毎回更新する
+		auto characterPosition = character->GetPos();
+
 		if (CharacterCollidesWithBlock(characterPrevious, characterSize, characterPosition, blockPosition))
 		{
 			Direction correction;


### PR DESCRIPTION
## 概要
<!-- このプルリクエストで、ソースコードにどのような変更を加えるのか -->
当たり判定の順番を変えたりする。
<!-- 関連するissue番号(プルリクmerge時に元issueを閉じて良いならcloses、そうで無ければrefs。) -->
closes #81 

## 変更内容
<!-- 変更した内容の詳細。リストにした場合は、各項目ごとにコミットが別れているとレビューしやすい -->
Collision.cpp
## 影響範囲
<!-- どの関数、変数に影響があるのか -->
std::vector<Position> SearchBlock(Character& character, int** map)
void CheckBlock(Character* character, std::vector<Position> blockPositions);